### PR TITLE
Add test-repo-without-catalog-file to Backstage Software Catalog

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,8 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: test-repo-without-catalog-file
+spec:
+  type: website
+  lifecycle: experimental
+  owner: test-team


### PR DESCRIPTION

## TL;DR

This pull request registers test-repo-without-catalog-file, as a component in our Backstage Software Catalog. 
It lists our team, test-team, as the owners of this component.
After this file has merged, you can view this component in Backstage Software Catalog here: → http://localhost/catalog

## What is Portal?

[Portal](https://backstage.spotify.com/products/portal) is an internal developer portal based on [Backstage](https://backstage.io/). It's goal is making developers' lives easier. Portal unifies all your infrastructure tooling, services, and documentation to create a streamlined development environment from end to end.
